### PR TITLE
Missing !default on a variable

### DIFF
--- a/_objects.list-inline.scss
+++ b/_objects.list-inline.scss
@@ -10,7 +10,7 @@
 $inuit-list-inline-namespace:           $inuit-namespace !default;
 
 $inuit-enable-list-inline--delimited:   false !default;
-$inuit-list-inline-delimit-character:   ",\00A0";
+$inuit-list-inline-delimit-character:   ",\00A0" !default;
 
 .#{$inuit-list-inline-namespace}list-inline,
 %#{$inuit-list-inline-namespace}list-inline {


### PR DESCRIPTION
Missing !default for `$inuit-list-inline-delimit-character`.

_I just add this module to my project and I already love it (image has nothing to do with the issue, just because I love working with inuitcss ;) )_
![capture decran 2014-07-24 a 21 40 18](https://cloud.githubusercontent.com/assets/2061540/3693688/84c0e5ee-136a-11e4-8089-949163113bb7.png)
_Next step for me : using bower (I will try it next week)_
